### PR TITLE
test python 2.6 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ python:
 
 script:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.6" ]]; then pip install unittest2 ; fi
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.6" ]]; then pip install flake8==2.6.2 ; fi
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.3" ]]; then pip install flake8==2.6.2 ; fi
   - python setup.py test
   - if [[ "$TRAVIS_PYTHON_VERSION" != "nightly" ]]; then coverage run setup.py test ; fi
 

--- a/test_flake8_future_import.py
+++ b/test_flake8_future_import.py
@@ -321,6 +321,9 @@ class FeaturesMetaClass(type):
     def __new__(cls, name, bases, dct):
         def create_existing_test(feat_name):
             def test(self):
+                if feat_name == 'absolute_import' and sys.version_info < (2, 7, 5):
+                    raise unittest.SkipTest('https://bugs.python.org/issue14494')
+
                 self.assertIn(feat_name, flake8_future_import.FEATURES)
                 py_feat = getattr(__future__, feat_name)
                 my_feat = flake8_future_import.FEATURES[feat_name]

--- a/test_flake8_future_import.py
+++ b/test_flake8_future_import.py
@@ -118,21 +118,15 @@ class SimpleImportTestCase(TestCaseBase):
 
 class MinVersionTestCase(TestCaseBase):
 
-    @classmethod
-    def setUpClass(cls):
-        super(MinVersionTestCase, cls).setUpClass()
-        cls._min_version = flake8_future_import.FutureImportChecker.min_version
-
-    @classmethod
-    def tearDownClass(cls):
-        flake8_future_import.FutureImportChecker.min_version = cls._min_version
-        super(MinVersionTestCase, cls).tearDownClass()
-
     def run_checker(self, min_version, ignored, *imported):
         tree = ast.parse(generate_code(*imported))
-        flake8_future_import.FutureImportChecker.min_version = min_version
-        checker = flake8_future_import.FutureImportChecker(tree, 'fn')
-        self.run_test(self.iterator(checker), imported, ignore_missing=ignored)
+        old_min = flake8_future_import.FutureImportChecker.min_version
+        try:
+            flake8_future_import.FutureImportChecker.min_version = min_version
+            checker = flake8_future_import.FutureImportChecker(tree, 'fn')
+            self.run_test(self.iterator(checker), imported, ignore_missing=ignored)
+        finally:
+            flake8_future_import.FutureImportChecker.min_version = old_min
 
     def test_mandatory_and_unavailable(self):
         """Do not care about already mandatory or not yet available features."""


### PR DESCRIPTION
Added python 2.6 is added to the build matrix since setup.py advertises support. Unfortunately, the tests don't pass. I took an initial stab at getting them to work, but there's at least one more bug remaining. I think it's worth noting that flake8 3 dropped support for python 2.6