### PR TITLE
Get the tests working again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ notifications:
 before_install:
   - pip install codecov
   - mkdir bad_tests
-  - wget https://hg.python.org/cpython/archive/tip.tar.bz2/Lib/test/ -O bad_tests/test.tar.bz2
+  - wget https://hg.python.org/cpython/archive/3.6.tar.bz2/Lib/test/ -O bad_tests/test.tar.bz2
   - tar -xjf bad_tests/test.tar.bz2 -C bad_tests/
   - mv bad_tests/cpython-*/Lib/test/badsyntax_future* . -v
   - rm -r bad_tests/

--- a/flake8_future_import.py
+++ b/flake8_future_import.py
@@ -204,7 +204,7 @@ def main(args):
                                                             filename).run():
             if msg[:4] not in ignored:
                 has_errors = True
-                print('{0}:{1}:{2}: {3}'.format(filename, line, char, msg))
+                print('{0}:{1}:{2}: {3}'.format(filename, line, char + 1, msg))
     return has_errors
 
 

--- a/test_flake8_future_import.py
+++ b/test_flake8_future_import.py
@@ -11,8 +11,6 @@ import subprocess
 import sys
 import tempfile
 
-from distutils.version import StrictVersion
-
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -87,13 +85,12 @@ class TestCaseBase(unittest.TestCase):
             self.assertEqual(char, 0)
             self.assertIs(origin, flake8_future_import.FutureImportChecker)
 
-    def reverse_parse(self, lines, expected_offset, tmp_file=None):
+    def reverse_parse(self, lines, tmp_file=None):
         for line in lines:
-            match = re.match(r'([^:]+):(\d+):(\d+): (.*)', line)
-            yield int(match.group(2)), match.group(4)
+            match = re.match(r'([^:]+):(\d+):1: (.*)', line)
+            yield int(match.group(2)), match.group(3)
             if tmp_file is not None:
                 self.assertEqual(match.group(1), tmp_file)
-            self.assertEqual(int(match.group(3)), expected_offset)
 
 
 class SimpleImportTestCase(TestCaseBase):
@@ -173,7 +170,7 @@ class TestMainPrintPatched(TestCaseBase):
             flake8_future_import.main([tmp_file])
         finally:
             os.remove(tmp_file)
-        self.run_test(self.reverse_parse(self.messages, 0), imported)
+        self.run_test(self.reverse_parse(self.messages), imported)
 
     def test_main(self):
         self.run_main()
@@ -264,14 +261,6 @@ class Flake8TestCase(TestCaseBase):
             else:
                 raise unittest.SkipTest('The plugin is not installed and '
                                         'TEST_FLAKE8_INSTALL not set')
-        # Determine version of installed flake8 package
-        for dist in pip.utils.get_installed_distributions(False):
-            if dist.key == 'flake8':
-                version = StrictVersion(dist.version)
-                cls.expected_offset = 0 if version.version[0] >= 3 else 1
-                break
-        else:
-            raise ValueError('Unable to find Flake8 installation')
         super(Flake8TestCase, cls).setUpClass()
 
     @classmethod
@@ -300,11 +289,8 @@ class Flake8TestCase(TestCaseBase):
             os.close(handle)
             os.remove(tmp_file)
         self.assertFalse(data_err)
-        self.run_test(
-            self.reverse_parse(data_out.decode('utf8').splitlines(),
-                               self.expected_offset,
-                               tmp_file),
-            imported)
+        self.run_test(self.reverse_parse(data_out.decode('utf8').splitlines(), tmp_file),
+                      imported)
         self.assertEqual(p.returncode, 1)
 
     def test_flake8(self):


### PR DESCRIPTION
* Reverted eaf2799f41ca3a5692fed2df4dfbc06b0627dcfe because that addressed a bug only present in 3.0.0 and 3.0.1
* Download specific versions of badsyntax to avoid test failures when tip becomes something unexpected