### PR TITLE
Support noqa for global import statement

### DIFF
--- a/flake8_future_import.py
+++ b/flake8_future_import.py
@@ -156,14 +156,16 @@ class FutureImportChecker(Flake8Argparse):
                 if err:
                     yield import_node.lineno, 0, err, type(self)
                 present.add(alias.name)
-        for name in FEATURES:
-            if name not in present:
-                err = self._generate_error(name, False)
-                if err:
-                    if len(self.tree.body) > 0 and self.tree.body[0].lineno > 1:
-                        yield self.tree.body[0].lineno - 1, 0, err, type(self)
-                    else:
-                        yield 1, 0, err, type(self)
+
+        for name in FEATURE_NAMES - present:
+            err = self._generate_error(name, False)
+            if not err:
+                continue
+
+            if len(self.tree.body) > 0 and self.tree.body[0].lineno > 1:
+                yield self.tree.body[0].lineno - 1, 0, err, type(self)
+            else:
+                yield 1, 0, err, type(self)
 
 
 def main(args):

--- a/flake8_future_import.py
+++ b/flake8_future_import.py
@@ -160,7 +160,10 @@ class FutureImportChecker(Flake8Argparse):
             if name not in present:
                 err = self._generate_error(name, False)
                 if err:
-                    yield 1, 0, err, type(self)
+                    if len(self.tree.body) > 0 and self.tree.body[0].lineno > 1:
+                        yield self.tree.body[0].lineno - 1, 0, err, type(self)
+                    else:
+                        yield 1, 0, err, type(self)
 
 
 def main(args):

--- a/test_flake8_future_import.py
+++ b/test_flake8_future_import.py
@@ -53,7 +53,6 @@ class TestCaseBase(unittest.TestCase):
                     self.assertEqual(match.group(2), imp)
                     if code < 50:
                         found_missing.add(imp)
-                        self.assertEqual(line, 1)
                     else:
                         found_forbidden.add(imp)
                 else:


### PR DESCRIPTION
# Problem
Previously if someone wants to ignore future import error, they have to add `# noqa: <CODES>` to top of the code as mentioned at #18.
This is because `flake8-future-import` report flake8 that error always occurred on line number 1.

# Solution
I set a rule that if someone wants to ignore `FIXX` error, he/she have to add `# noqa: <CODES>` right on top of first code block (e.g. import statement, global variable declaration, ....)

## Examples

```Python
#!/usr/bin/env python
# coding: UTF-8
# noqa: FI14
import ast

pass
```

```Python
# -*- coding: utf-8 -*-

# noqa: FI12
global_var = set()

def foo():
    pass

pass
```

```Python
# noqa: FI12
def foo():
    pass

pass
```

Fixes #18